### PR TITLE
OP-609 Resolve issues caused by replacing text tracks from BrightCove…

### DIFF
--- a/ios/RNGoogleCast/RNGoogleCast.m
+++ b/ios/RNGoogleCast/RNGoogleCast.m
@@ -250,8 +250,9 @@ RCT_EXPORT_METHOD(castMedia: (NSDictionary *)params
   NSMutableArray *tracks = [[NSMutableArray alloc] init];
   if ([textTracks[0] count] > 0) {
     GCKMediaTrack *captionsTrack;
+    int trackId = 1;
     for (NSDictionary *track in textTracks) {        
-      captionsTrack = [[GCKMediaTrack alloc] initWithIdentifier:track[@"srclang"]
+      captionsTrack = [[GCKMediaTrack alloc] initWithIdentifier:trackId
                               contentIdentifier:track[@"src"]
                                     contentType:track[@"mime_type"]
                                             type:GCKMediaTrackTypeText
@@ -260,6 +261,7 @@ RCT_EXPORT_METHOD(castMedia: (NSDictionary *)params
                                     languageCode:track[@"srclang"]
                                       customData:nil];
       [tracks addObject: captionsTrack];
+      trackId++;
     }
   }
   else {


### PR DESCRIPTION
I replaced the BrightCove text tracks name "Track #" by adding text tracks with proper names. It caused some issues with playing cast video in expanded controller because the text tracks were not replaced properly. I'm making a change to show both correct subtitle name and Track # name for now as shown in below image to resolve the issues.
<img width="367" alt="Screen Shot 2020-03-05 at 12 55 40 PM" src="https://user-images.githubusercontent.com/54517709/76362069-924c7480-62dd-11ea-9ea0-a04ccbea8993.png">
